### PR TITLE
Refactored list-ports

### DIFF
--- a/src/serial/util.clj
+++ b/src/serial/util.clj
@@ -4,7 +4,4 @@
 (defn list-ports
   "Print out the available ports. The names are printed exactly as they should be passed to open."
   []
-  (loop [ports (port-ids)]
-    (when ports
-      (println (.getName (first ports)))
-      (recur (next ports)))))
+  (doall (map #(println (.getName %)) (port-ids))))


### PR DESCRIPTION
Refactored the `serial.util/list-ports` method to use `map` instead of `loop/recur`, to make it more idiomatic.
