### PR TITLE
Reflection cleanup (and readme update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ However, you'll want to bind the result so you can use it later:
 
 If you wish to get raw access to the `InputStream` this is possible with the function `listen`. This allows you to specify a handler that will get called every time there is data available on the port and will pass your handler the `InputStream` to allow you to directly `.read` bytes from it.
 
-When the handler is first registered, the bytes that have been buffered on the serial port are dropped by default. This can be changed by passing false to `on-byte`, `on-n-bytes` or `listen` as an optional last argument.
+When the handler is first registered, the bytes that have been buffered on the serial port are dropped by default. This can be changed by passing false to `listen!` as an optional last argument.
 
 Only one listener may be registered at a time. If you want to fork the incoming datastream to a series of streams, you might want to consider using lamina. You can then register a handler which simply enqueues the incoming serial data to a lamina channel which you may then fork and map according to your whim.
 
-Finally, you may remove your listener with `remove-listener`.
+Finally, you may remove your listener by calling `unlisten!` and passing it the port binding.
 
 ### Writing bytes
 
@@ -72,9 +72,9 @@ As well as any `Sequential`
 
 ### Closing the port
 
-Simply use the `close` function:
+Simply use the `close!` function:
 
-    (close port)
+    (close! port)
 
 ## Contributors
 

--- a/test/serial/test/core.clj
+++ b/test/serial/test/core.clj
@@ -4,12 +4,13 @@
   (:import [purejavacomm CommPortIdentifier]
            [java.util Enumeration]
            [java.io ByteArrayOutputStream]
-           [java.nio ByteBuffer]))
+           [java.nio ByteBuffer]
+           [serial.core Port]))
 
 
 (defn- mock-port
   []
-  {:out-stream (ByteArrayOutputStream.)})
+  (Port. "test" nil (ByteArrayOutputStream.) nil))
 
 (defn- byte-at
   [port index]


### PR DESCRIPTION
This is primarily a reflection cleanup, as the runtime cost (both in terms of performance and memory) is hurting me on the lower end devices I'm targeting. The only caution is that to do the cleanup is that I made the assumption that people were only opening up serial ports (and not parallel ports). I believe this is a valid assumption for people using the library, but if it's not please let me know.

Additionally I changed the dereferences of the Port record to use the java object form as that is more performant on accessing members of the record without having any readibility problems.

Finally I updated README.md to remove the on-byte methods that weren't there, and to suggest the use of the close! and listen! forms rather then the deprecated ones.