### PR TITLE
Add a helper for skipping input stream data

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.sparetimelabs/purejavacomm "1.0.0"]]
+                 [com.sparetimelabs/purejavacomm "1.0.1"]]
   :repositories [["javacomm" "http://www.sparetimelabs.com/maven2"]]
   :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}

--- a/src/serial/core.clj
+++ b/src/serial/core.clj
@@ -119,6 +119,11 @@
     (write-bytes port (to-bytes x)))
   port)
 
+(defn skip-input!
+  "Skips a specified amount of buffered input data."
+  ([^Port port] (skip-input! port (.available ^InputStream (.in-stream port))))
+  ([^Port port ^long to-drop]
+    (.skip ^InputStream (.in-stream port) to-drop)))
 
 (defn listen!
   "Register a function to be called for every byte received on the specified port.
@@ -133,9 +138,8 @@
                                                        (.getEventType event))
                                                 (handler in-stream))))]
 
-       (if skip-buffered?
-         (let [to-drop (.available in-stream)]
-           (.skip in-stream to-drop)))
+       (when skip-buffered?
+         (skip-input! port))
 
        (.addEventListener raw-port listener)
        (.notifyOnDataAvailable raw-port true))))


### PR DESCRIPTION
I find it quite useful to be able to skip all buffered input data on a port, and have been doing this externally to clj-serial, but it makes a lot of sense as a helper function, especially since clj-serial already has to perform this action.