### PR TITLE
Add get-port-names helper to util

### DIFF
--- a/src/serial/util.clj
+++ b/src/serial/util.clj
@@ -1,8 +1,14 @@
 (ns serial.util
-  (:require [serial.core :refer [port-identifiers]]))
+  (:require [serial.core :refer [port-identifiers]])
+  (:import [purejavacomm CommPortIdentifier]))
+
+(defn get-port-names
+  "Gets a set of the currently avilable port names"
+  []
+  (set (map #(.getName ^CommPortIdentifier %) (port-identifiers))))
 
 (defn list-ports
   "Print out the available ports.
    The names printed may be passed to `serial.core/open` as printed."
   []
-  (doall (map #(println (.getName %)) (port-identifiers))))
+  (doall (map println (get-port-names))))


### PR DESCRIPTION
It's frequently useful to get the set of the available port names, and then be able to do work over it. This just exposes a helper so that the caller doesn't need to know what a CommPortIdentifier is and how to get it's name.