### PR TITLE
Add OpenJDK6 to travis deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: clojure
-lein: lein2
-script: lein2 test
 jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk7
+  - openjdk8
+  - oraclejdk8
+  - oraclejdk9

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.sparetimelabs/purejavacomm "1.0.1"]]
-  :repositories [["javacomm" "http://www.sparetimelabs.com/maven2"]]
+                 [com.github.purejavacomm/purejavacomm "1.0.2.RELEASE"]]
   :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :scm {:name "git"


### PR DESCRIPTION
Attempting to fix the OpenJDK6 error in #10

EDIT: I really should just enable Travis on my fork rather then using PR's to do Travis runs.